### PR TITLE
update dependency graph to use setup-scala

### DIFF
--- a/.github/workflows/sbt-dependency-graph.yml
+++ b/.github/workflows/sbt-dependency-graph.yml
@@ -8,14 +8,8 @@ jobs:
   dependency-graph:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout branch
-        id: checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - name: Submit dependencies
-        id: submit
-        uses: scalacenter/sbt-dependency-submission@7ebd561e5280336d3d5b445a59013810ff79325e # v3.0.1
-      - name: Log snapshot for user validation
-        id: validate
-        run: cat ${{ steps.submit.outputs.snapshot-json-path }} | jq
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: guardian/setup-scala@v1
+      - uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0
     permissions:
       contents: write


### PR DESCRIPTION
The current version of the dependency graph updator workflow doesn't use setup-scala, so doesn't have sbt installed. 

Use setup-scala, and have sbt installed.