### PR TITLE
Switch to KCL v3 in compatibility mode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ val PekkoVersion = "1.1.2"
 
 val slf4j = "org.slf4j" % "slf4j-api" % "1.7.32"
 val logback = "ch.qos.logback" % "logback-classic" % "1.2.5"
-val amazonKinesisClient = "software.amazon.kinesis" % "amazon-kinesis-client" % "2.6.0"
+val amazonKinesisClient = "software.amazon.kinesis" % "amazon-kinesis-client" % "3.0.1"
 val amazonKinesisProducer = "com.amazonaws" % "amazon-kinesis-producer" % "0.12.11"
 val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.2.9"

--- a/src/main/scala/com/gu/kinesis/KinesisSource.scala
+++ b/src/main/scala/com/gu/kinesis/KinesisSource.scala
@@ -7,6 +7,7 @@ import org.apache.pekko.{Done, NotUsed}
 import org.slf4j.LoggerFactory
 import software.amazon.awssdk.services.dynamodb.model.BillingMode
 import software.amazon.kinesis.common.ConfigsBuilder
+import software.amazon.kinesis.coordinator.CoordinatorConfig.ClientVersionConfig
 import software.amazon.kinesis.coordinator.Scheduler
 import software.amazon.kinesis.processor.{ShardRecordProcessor, ShardRecordProcessorFactory}
 import software.amazon.kinesis.retrieval.RetrievalConfig
@@ -110,6 +111,7 @@ object KinesisSource {
 
     val checkpointConfig = configsBuilder.checkpointConfig()
     val coordinatorConfig = config.coordinatorConfig.getOrElse(configsBuilder.coordinatorConfig())
+      .clientVersionConfig(ClientVersionConfig.CLIENT_VERSION_CONFIG_COMPATIBLE_WITH_2X)
     val leaseManagementConfig = config.leaseManagementConfig.getOrElse(
       configsBuilder
         .leaseManagementConfig()


### PR DESCRIPTION
Start creating a new version with KCL v3, running in v2 compatibility mode as described in the migration guide <https://docs.aws.amazon.com/streams/latest/dev/kcl-migration-from-2-3.html>.

A subsequent version will update to run in v3 mode. 

The library is already following the best practices for the `shutdownRequested` handler in part 4.

Consumers will be responsible for following the remaining steps of the migration guide, especially steps 5 & 6.