### PR TITLE
add dependencyOverride on jackson to suppress reported warning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,4 +52,5 @@ libraryDependencies ++= Seq(
 dependencyOverrides ++= Seq(
   "org.apache.avro" % "avro" % "1.11.4",
   "org.json" % "json" % "20231013",
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.19.1",
 )


### PR DESCRIPTION
CVE reported in Jackson before 2.15. The dependency comes from transitive dependencies, so properly fixing the tree is tricky and best left to consumers. The override here will not affect consumers, but will switch to a modern jackson when running tests locally and in CI.