### PR TITLE
upgrade kinesis-client-library to 3.2.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ val PekkoVersion = "1.1.2"
 
 val slf4j = "org.slf4j" % "slf4j-api" % "1.7.32"
 val logback = "ch.qos.logback" % "logback-classic" % "1.5.19"
-val amazonKinesisClient = "software.amazon.kinesis" % "amazon-kinesis-client" % "3.0.2"
+val amazonKinesisClient = "software.amazon.kinesis" % "amazon-kinesis-client" % "3.2.1"
 val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.2.9"
 val scalaMock = "org.scalamock" %% "scalamock" % "5.1.0"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Upgrades to the latest version of KCL, which includes https://github.com/awslabs/amazon-kinesis-client/pull/1482 which may unblock Grid from upgrading to KCL 3

This upgrade also updates a transitive dependency which resolves a high vulnerability report.