### PR TITLE
upgrade kinesis-client version to receive new upgrades

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ val PekkoVersion = "1.1.2"
 
 val slf4j = "org.slf4j" % "slf4j-api" % "1.7.32"
 val logback = "ch.qos.logback" % "logback-classic" % "1.5.19"
-val amazonKinesisClient = "software.amazon.kinesis" % "amazon-kinesis-client" % "3.4.1"
+val amazonKinesisClient = "software.amazon.kinesis" % "amazon-kinesis-client" % "3.4.2"
 val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.2.9"
 val scalaMock = "org.scalamock" %% "scalamock" % "5.1.0"

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ val PekkoVersion = "1.1.2"
 
 val slf4j = "org.slf4j" % "slf4j-api" % "1.7.32"
 val logback = "ch.qos.logback" % "logback-classic" % "1.5.19"
-val amazonKinesisClient = "software.amazon.kinesis" % "amazon-kinesis-client" % "3.2.1"
+val amazonKinesisClient = "software.amazon.kinesis" % "amazon-kinesis-client" % "3.4.1"
 val scalaCollectionCompat = "org.scala-lang.modules" %% "scala-collection-compat" % "2.5.0"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.2.9"
 val scalaMock = "org.scalamock" %% "scalamock" % "5.1.0"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The new kinesis-client version includes transitive fixes for several high vulnerabilities

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
